### PR TITLE
fix service name for postgres

### DIFF
--- a/docker/compose/indexer-postgres/docker-compose.yaml
+++ b/docker/compose/indexer-postgres/docker-compose.yaml
@@ -1,6 +1,6 @@
 version: "3.8"
 services:
-  db:
+  postgres:
     container_name: postgres
     image: postgres
     restart: always


### PR DESCRIPTION
The docker-compose.yaml specifies the indexer dependency on postgres. But the postgres service itself is called db, which caused an error on startup

### Description
Change 'db' to 'postgres' in docker-compose.yaml
### Test Plan
docker-compose up -d
